### PR TITLE
Fix hard-coded amd64 paths on non x86_64 builders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REGISTRY?=directxman12
 IMAGE?=k8s-prometheus-adapter
 TEMP_DIR:=$(shell mktemp -d)
-ARCH?=amd64
+ARCH?=$(shell go env GOARCH)
 ALL_ARCH=amd64 arm arm64 ppc64le s390x
 ML_PLATFORMS=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x
 OUT_DIR?=./_output


### PR DESCRIPTION
The Dockerfile does not pass the ARCH to the Makefile, which results in non x86_64 builds failing due to hardcoded amd64 paths.  This change uses GOARCH  as the default ARCH, instead of hardcoding amd64 into the Makefile.