### PR TITLE
*: set -mod="vendor" to build OCP container image

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -3,6 +3,7 @@ FROM openshift/origin-release:golang-1.12 AS builder
 COPY . /go/src/github.com/directxman12/k8s-prometheus-adapter
 
 WORKDIR /go/src/github.com/directxman12/k8s-prometheus-adapter
+ENV GOFLAGS="-mod=vendor"
 RUN make
 RUN mv /go/src/github.com/directxman12/k8s-prometheus-adapter/_output/$(go env GOARCH)/adapter /usr/bin/cm-adapter
 


### PR DESCRIPTION
OCP images should be able to be built without contacting external services.

This should fix recent OSBS build problem.

/cc @s-urbaniak 