### PR TITLE
Adding build support for archs other than amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REGISTRY?=directxman12
 IMAGE?=k8s-prometheus-adapter
 TEMP_DIR:=$(shell mktemp -d)
-ARCH?=amd64
+ARCH?=$(shell go env GOARCH)
 ALL_ARCH=amd64 arm arm64 ppc64le s390x
 ML_PLATFORMS=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x
 OUT_DIR?=./_output


### PR DESCRIPTION
This PR removes hardcoded `amd64` and replaces it with env GOARCH, which enables the build to create binaries for the platform it is running on.