### PR TITLE
Bug 1867510: fix CVP issues due to incorrect labels set

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.13 AS builder
+FROM openshift/origin-release:golang-1.14 AS builder
 
 COPY . /go/src/github.com/directxman12/k8s-prometheus-adapter
 
@@ -15,7 +15,8 @@ COPY --from=builder /usr/bin/cm-adapter /usr/bin/cm-adapter
 LABEL io.k8s.display-name="OpenShift Prometheus Custom Metrics Adapter" \
       io.k8s.description="This is a component of OpenShift Container Platform that provides the Kubernetes custom metrics API based on Prometheus metrics" \
       io.openshift.tags="openshift" \
-      maintainer="Solly Ross <sross@redhat.com>"
+      summary="This is a component of OpenShift Container Platform that provides the Kubernetes custom metrics API based on Prometheus metrics" \
+      maintainer="OpenShift Monitoring Team <team-monitoring@redhat.com>"
 
 USER 1001
 


### PR DESCRIPTION
- Fixing maintainer label to end with @redhat.com as this is expected
- Overriding summary label as it is inherited from base image and results with an incorrect value
- explicit usage of golang 1.14

/cc @openshift/openshift-team-monitoring