### PR TITLE
Updating ose-prometheus-adapter builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 
 COPY . /go/src/github.com/directxman12/k8s-prometheus-adapter
 
@@ -8,7 +8,7 @@ RUN make
 RUN mv /go/src/github.com/directxman12/k8s-prometheus-adapter/_output/$(go env GOARCH)/adapter /usr/bin/cm-adapter
 
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 COPY --from=builder /usr/bin/cm-adapter /usr/bin/cm-adapter
     


### PR DESCRIPTION
Updating ose-prometheus-adapter builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-prometheus-adapter.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.