### PR TITLE
Revert "OCPBUGS-24155: Updating ose-prometheus-adapter-container image to be consistent with ART"

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.20-openshift-4.15
+  tag: rhel-8-release-golang-1.20-openshift-4.15

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
 
 COPY . /go/src/github.com/kubernetes-sigs/prometheus-adapter
 
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/kubernetes-sigs/prometheus-adapter
 RUN make
 RUN mv /go/src/github.com/kubernetes-sigs/prometheus-adapter/adapter /usr/bin/adapter
 
-FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.15:base
 
 COPY --from=builder /usr/bin/adapter /usr/bin/adapter
     


### PR DESCRIPTION
Reverts openshift/k8s-prometheus-adapter#95

It seems that it's breaking promotion jobs since merged.