### PR TITLE
[release-4.15] OCPBUGS-35820: Fix the podmetrics and nodemetrics command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,3 +115,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace sigs.k8s.io/metrics-server => github.com/slashpai/metrics-server v0.0.0-20240919063601-b54e3f03e27d

--- a/go.sum
+++ b/go.sum
@@ -486,6 +486,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
+github.com/slashpai/metrics-server v0.0.0-20240919063601-b54e3f03e27d h1:z/jzuontmis3rEG8saaygnh4U8CtS32st95Ad/1LYZc=
+github.com/slashpai/metrics-server v0.0.0-20240919063601-b54e3f03e27d/go.mod h1:eYoM0c4p7XoWkUWzztpAydqkHRRblo4luZY8ex9fxcA=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -1107,8 +1109,6 @@ sigs.k8s.io/custom-metrics-apiserver v1.27.0/go.mod h1:204Z2fcsiUjBM0UV6o3TCqfvm
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/metrics-server v0.0.0-20230614201618-5daafd91f747 h1:I+yjc9sFaIWpwPEhEV9b2DYAkiwMuDeaVkxjBMvXf9g=
-sigs.k8s.io/metrics-server v0.0.0-20230614201618-5daafd91f747/go.mod h1:eYoM0c4p7XoWkUWzztpAydqkHRRblo4luZY8ex9fxcA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1193,7 +1193,7 @@ sigs.k8s.io/custom-metrics-apiserver/pkg/registry/external_metrics
 ## explicit; go 1.18
 sigs.k8s.io/json
 sigs.k8s.io/json/internal/golang/encoding/json
-# sigs.k8s.io/metrics-server v0.0.0-20230614201618-5daafd91f747
+# sigs.k8s.io/metrics-server v0.0.0-20230614201618-5daafd91f747 => github.com/slashpai/metrics-server v0.0.0-20240919063601-b54e3f03e27d
 ## explicit; go 1.20
 sigs.k8s.io/metrics-server/pkg/api
 # sigs.k8s.io/structured-merge-diff/v4 v4.2.3
@@ -1206,3 +1206,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# sigs.k8s.io/metrics-server => github.com/slashpai/metrics-server v0.0.0-20240919063601-b54e3f03e27d

--- a/vendor/sigs.k8s.io/metrics-server/pkg/api/node.go
+++ b/vendor/sigs.k8s.io/metrics-server/pkg/api/node.go
@@ -178,5 +178,5 @@ func (m *nodeMetrics) NamespaceScoped() bool {
 
 // GetSingularName implements rest.SingularNameProvider interface
 func (m *nodeMetrics) GetSingularName() string {
-	return "node"
+	return ""
 }

--- a/vendor/sigs.k8s.io/metrics-server/pkg/api/pod.go
+++ b/vendor/sigs.k8s.io/metrics-server/pkg/api/pod.go
@@ -185,5 +185,5 @@ func (m *podMetrics) NamespaceScoped() bool {
 
 // GetSingularName implements rest.SingularNameProvider interface
 func (m *podMetrics) GetSingularName() string {
-	return "pod"
+	return ""
 }


### PR DESCRIPTION
**Did following to fix**

cherry-picked the [metrics-server fix](https://github.com/kubernetes-sigs/metrics-server/pull/1436) on top of existing metrics-server commit hash prometheus-adapter is pointed at to my metrics-server fork.

We cannot directly fix this in downstream metrics-server 4.15 fork because its in release-0.6 version which doesn't have this change at all and diverged from release 0.7.

We cannot point directly to 0.7.2 metrics-server because it depends on 1.29 k8s and 4.15 is in 1.27


